### PR TITLE
Update image registry

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -10,7 +10,7 @@ on:
 
 env:
   IMAGE_REGISTRY: quay.io/redhat-saia/chatbot-ui-patternfly
-  IMAGE_BASE_REGISTRY: quay.io
+  IMAGE_BASE_REGISTRY: quay.io/redhat-composer-ai/composer-ai-studio 
 
 jobs:
   lint:
@@ -81,8 +81,8 @@ jobs:
       - name: Login to Docker Registry
         uses: docker/login-action@v1
         with:
-          username: ${{ secrets.REGISTRY_USER }}
-          password: ${{ secrets.REGISTRY_PASSWORD }}
+          username: ${{ secrets.QUAY_USER }}
+          password: ${{ secrets.QUAY_PASSWORD }}
           registry: ${{ env.IMAGE_BASE_REGISTRY }}
       
       - name: Download node modules

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # Composer AI Studio
 
+[![Build Image](https://github.com/redhat-composer-ai/chatbot-ui/actions/workflows/ci.yaml/badge.svg)](https://github.com/redhat-composer-ai/chatbot-ui/actions/workflows/ci.yaml)
+
+[![GitHub](https://img.shields.io/badge/GitHub-repo-blue.svg)](https://github.com/redhat-composer-ai/chatbot-ui) [![Quay.io](https://img.shields.io/badge/Quay.io-image-blue.svg)](https://quay.io/repository/redhat-composer-ai/composer-ai-studio)
+
 Composer AI Studio is based off PatternFly Seed.
 
 Patternfly Seed is an open source build scaffolding utility for web apps. The primary purpose of this project is to give developers a jump start when creating new projects that will use patternfly. A secondary purpose of this project is to serve as a reference for how to configure various aspects of an application that uses patternfly, webpack, react, typescript, etc.


### PR DESCRIPTION
I setup a new image registry here:

https://quay.io/repository/redhat-composer-ai/composer-ai-studio?tab=info

I know the build/push process is not currently being run, but I wanted to get this setup for when you all do decide you want to turn it back on.

Also, we should consider renaming this repo to `composer-ai-studio`.