### PR TITLE
Edit functionality

### DIFF
--- a/src/app/FlyoutFooter/FlyoutFooter.tsx
+++ b/src/app/FlyoutFooter/FlyoutFooter.tsx
@@ -9,7 +9,10 @@ interface FlyoutFooterProps {
   onSecondaryButtonClick?: () => void;
   dangerSecondaryButton?: string;
   onDangerSecondaryButtonClick?: () => void;
+  thirdButton?: string;
+  thirdButtonClick?: () => void;
   isPrimaryButtonDisabled?: boolean;
+  isThirdButtonDisabled?: boolean;
 }
 export const FlyoutFooter: React.FunctionComponent<FlyoutFooterProps> = ({
   primaryButton,
@@ -17,8 +20,11 @@ export const FlyoutFooter: React.FunctionComponent<FlyoutFooterProps> = ({
   secondaryButton,
   onSecondaryButtonClick,
   dangerSecondaryButton,
+  thirdButtonClick,
+  thirdButton,
   onDangerSecondaryButtonClick,
   isPrimaryButtonDisabled,
+  isThirdButtonDisabled,
 }: FlyoutFooterProps) => {
   return (
     <div className="flyout-footer">
@@ -33,6 +39,13 @@ export const FlyoutFooter: React.FunctionComponent<FlyoutFooterProps> = ({
             {dangerSecondaryButton}
           </Button>
         )}
+
+        {thirdButton && thirdButtonClick && (
+          <Button isDisabled={isThirdButtonDisabled} variant="tertiary" onClick={thirdButtonClick}>
+            {thirdButton}
+          </Button>
+        )}
+
         <Button isDisabled={isPrimaryButtonDisabled} onClick={onPrimaryButtonClick}>
           {primaryButton}
         </Button>

--- a/src/app/FlyoutForm/AssistantFlyoutForm.tsx
+++ b/src/app/FlyoutForm/AssistantFlyoutForm.tsx
@@ -67,7 +67,7 @@ export const AssistantFlyoutForm: React.FunctionComponent<AssistantFlyoutFormPro
   const [prompt, setPrompt] = React.useState<string>();
   const [questions, setQuestions] = React.useState<string[]>([]);
   const [questionsValidated, setQuestionsValidated] = React.useState<questionsValidate>('default');
-  const { nextStep, prevStep, setReloadList } = useFlyoutWizard();
+  const { nextStep, prevStep, setReloadList, wizardData } = useFlyoutWizard();
   const { chatbots } = useAppData();
   const globalConfig = useConfig();
 
@@ -141,13 +141,44 @@ export const AssistantFlyoutForm: React.FunctionComponent<AssistantFlyoutFormPro
     loadData();
   }, []);
 
+  React.useEffect(() => {
+    if (wizardData.editingAssistant != undefined) {
+      const initialTitle = wizardData.editingAssistant.name ?? ""
+      setTitle(initialTitle);
+      handleTitleChange(null, initialTitle);
+
+      setDisplayName(wizardData.editingAssistant.displayName ?? wizardData.editingAssistant.name ?? "");
+      setDescription(wizardData.editingAssistant.description ?? "");
+      setPrompt(wizardData.editingAssistant.userPrompt);
+      setQuestions(wizardData.editingAssistant.exampleQuestions || []);
+
+      const llm : LLMAPIResponse = {
+        name: wizardData.editingAssistant.llmConnection?.name ?? "",
+        id: wizardData.editingAssistant.llmConnection?.id ?? "",
+        description: wizardData.editingAssistant.llmConnection?.description ?? "",
+      }
+      setSelectedLLM(llm);
+
+      const retriever : RetrieverAPIResponse = {
+        id: wizardData.editingAssistant.retrieverConnection?.id ?? "",
+        name: wizardData.editingAssistant.retrieverConnection?.name ?? "",
+        description: wizardData.editingAssistant.retrieverConnection?.description ?? "",
+        connectionEntity: wizardData.editingAssistant.retrieverConnection?.connectionEntity ?? "",
+      }
+      setSelectedRetriever(retriever);
+
+    }
+  }, [wizardData.editingAssistant]);
+
   const chatbotExists = (title: string) => {
     return chatbots.filter((chatbot) => chatbot.name === title).length >= 1;
   };
 
   const handleTitleChange = (_event, title: string) => {
     setTitle(title);
-    if (title.trim() === '') {
+    if (wizardData.editingAssistant !== undefined && wizardData.editingAssistant.id !== null) {
+      setValidated('success');
+    } else if (title.trim() === '') {
       setValidated('default');
     } else if (!chatbotExists(title)) {
       setValidated('success');
@@ -217,15 +248,32 @@ export const AssistantFlyoutForm: React.FunctionComponent<AssistantFlyoutFormPro
 
   const createAssistant = async () => {
     const url = globalConfig?.REACT_APP_BASE_URL + '/admin/assistant/' || '';
-    const payload = {
+    const payload: {
+      id?: string;
+      name: string;
+      displayName: string;
+      description: string;
+      llmConnectionId?: string;
+      retrieverConnectionId?: string;
+      userPrompt?: string;
+      exampleQuestions?: string[];
+    } = {
       name: title,
       displayName: displayName ?? title,
       description: description,
       llmConnectionId: selectedLLM?.id,
-      retrieverConnectionId: selectedRetriever?.id,
       userPrompt: prompt,
       exampleQuestions: questions,
     };
+
+    if ( wizardData.editingAssistant != undefined) {
+      payload.id = wizardData.editingAssistant.id;
+    }
+
+    // support assistants without RAG
+    if (selectedRetriever && selectedRetriever.id !== "") {
+      payload.retrieverConnectionId = selectedRetriever.id;
+    }
 
     try {
       // handle if no llms
@@ -289,6 +337,7 @@ export const AssistantFlyoutForm: React.FunctionComponent<AssistantFlyoutFormPro
                 name="flyout-form-title"
                 value={title}
                 onChange={handleTitleChange}
+                isDisabled={wizardData.editingAssistant !== undefined && wizardData.editingAssistant.id !== null}
               />
               <FormHelperText>
                 <HelperText>
@@ -445,7 +494,7 @@ export const AssistantFlyoutForm: React.FunctionComponent<AssistantFlyoutFormPro
       {!error && (
         <FlyoutFooter
           isPrimaryButtonDisabled={title === '' || (llms.length > 0 && !selectedLLM) || validated !== 'success'}
-          primaryButton="Create assistant"
+          primaryButton={wizardData.editingAssistant !== undefined && wizardData.editingAssistant.id !== null ?  "Update assistant" : "Create assistant"}
           onPrimaryButtonClick={onClick}
           secondaryButton="Cancel"
           onSecondaryButtonClick={prevStep}

--- a/src/app/FlyoutForm/KnowledgeSourceFlyoutForm.tsx
+++ b/src/app/FlyoutForm/KnowledgeSourceFlyoutForm.tsx
@@ -34,11 +34,11 @@ export const KnowledgeSourceFlyoutForm: React.FunctionComponent<KnowledgeSourceF
 
   const [validated, setValidated] = React.useState<validate>('default');
   const [error, setError] = React.useState<ErrorObject>();
-  const { nextStep, prevStep } = useFlyoutWizard();
+  const { nextStep, prevStep, wizardData } = useFlyoutWizard();
 
   // UI State
   const [isKnowledgeSourceOpen, setIsKnowledgeSourceOpen] = React.useState(false);
-  
+
   // Form Fields
   const [name, setName] = React.useState('');
   const [description, setDescription] = React.useState('');
@@ -68,7 +68,7 @@ export const KnowledgeSourceFlyoutForm: React.FunctionComponent<KnowledgeSourceF
       setValidated('success');
     }
   }
-  
+
   const handleNameChange = (_event, name: string) => {
     setName(name);
   };
@@ -108,7 +108,7 @@ export const KnowledgeSourceFlyoutForm: React.FunctionComponent<KnowledgeSourceF
       contentRetrieverType: "elasticsearch"
     }
 
-    const payload : CreateRetrieverConnectionRequest = 
+    const payload : CreateRetrieverConnectionRequest =
     {
       name: name.trim() === '' ? undefined : name,
       description: description.trim() === '' ? undefined : description,
@@ -119,7 +119,7 @@ export const KnowledgeSourceFlyoutForm: React.FunctionComponent<KnowledgeSourceF
     try {
       return await knowledgeSourceAPI.createOrUpdateRetrieverConnection(payload);
     } catch (error) {
-      console.error('Error creating retriever:', error);  
+      console.error('Error creating retriever:', error);
       const axiosError: AxiosError = error as AxiosError;
       const response = axiosError.response;
 
@@ -134,7 +134,7 @@ export const KnowledgeSourceFlyoutForm: React.FunctionComponent<KnowledgeSourceF
       } else {
         setError({ title: 'Error creating retriever', body: axiosError?.message });
       }
-      
+
       console.error('Error creating retriever:', error);
     }
   };
@@ -161,6 +161,17 @@ export const KnowledgeSourceFlyoutForm: React.FunctionComponent<KnowledgeSourceF
     // For now we don't need to do anything on
     setIsLoading(false);
   }, []);
+
+  React.useEffect(() => {
+    if (wizardData.editingRetriever != undefined) {
+      console.log("loading retriver elements");
+      setName(wizardData.editingRetriever.name ?? "");
+      setDescription(wizardData.editingRetriever.description ?? "");
+      setEmbeddingType(wizardData.editingRetriever.embeddingType ?? "");
+      setIndex(wizardData.editingRetriever.connectionEntity.index ?? "");
+      setHost(wizardData.editingRetriever.connectionEntity.host ?? "");
+    }
+  }, [wizardData.editingRetriever]);
 
   return isLoading ? (
     <FlyoutLoading />
@@ -313,7 +324,7 @@ export const KnowledgeSourceFlyoutForm: React.FunctionComponent<KnowledgeSourceF
       {!error && (
         <FlyoutFooter
           isPrimaryButtonDisabled={validated !== 'success'}
-          primaryButton="Create Knowledge Source"
+          primaryButton={wizardData.editingRetriever !== undefined && wizardData.editingRetriever.id !== null ?  "Update Knowledge Source" : "Create Knowledge Source"}
           onPrimaryButtonClick={onClick}
           secondaryButton="Cancel"
           onSecondaryButtonClick={prevStep}

--- a/src/app/FlyoutForm/LLMConnectionFlyoutForm.tsx
+++ b/src/app/FlyoutForm/LLMConnectionFlyoutForm.tsx
@@ -37,15 +37,15 @@ const SERVING_RUNTIME_TYPE = ['openai'];
 
 export const LLMConnectionFlyoutForm: React.FunctionComponent<LLMConnectionFlyoutFormProps> = ({ header, hideFlyout }: LLMConnectionFlyoutFormProps) => {
   const [isLoading, setIsLoading] = React.useState(true);
-  
+
   const [validated, setValidated] = React.useState<validate>('default');
   const [error, setError] = React.useState<ErrorObject>();
-  const { nextStep, prevStep } = useFlyoutWizard();
+  const { nextStep, prevStep, wizardData } = useFlyoutWizard();
 
   // UI State
   const [isModelTypeOpen, setIsModelTypeOpen] = React.useState(false);
   const [isServingRuntimeTypeOpen, setIsServingRuntimeTypeOpen] = React.useState(false);
-  
+
   // Form Fields
   const [name, setName] = React.useState('');
   const [description, setDescription] = React.useState('');
@@ -80,7 +80,7 @@ export const LLMConnectionFlyoutForm: React.FunctionComponent<LLMConnectionFlyou
       setValidated('success');
     }
   }
-  
+
   const handleNameChange = (_event, name: string) => {
     setName(name);
   };
@@ -124,7 +124,7 @@ export const LLMConnectionFlyoutForm: React.FunctionComponent<LLMConnectionFlyou
 
   const createLLMConnection = async () => {
 
-    const payload : LLMConnection = 
+    const payload : LLMConnection =
     {
       name: name,
       description: description,
@@ -137,10 +137,14 @@ export const LLMConnectionFlyoutForm: React.FunctionComponent<LLMConnectionFlyou
       maxTokens: maxTokens
     }
 
+    if (wizardData.editingLlm != undefined) {
+      payload.id = wizardData.editingLlm.id;
+    }
+
     try {
       return await llmConnectionAPI.createOrUpdateLlmConnection(payload);
     } catch (error) {
-      console.error('Error creating retriever:', error);  
+      console.error('Error creating retriever:', error);
       const axiosError: AxiosError = error as AxiosError;
       const response = axiosError.response;
 
@@ -155,7 +159,7 @@ export const LLMConnectionFlyoutForm: React.FunctionComponent<LLMConnectionFlyou
       } else {
         setError({ title: 'Error creating retriever', body: axiosError?.message });
       }
-      
+
       console.error('Error creating retriever:', error);
     }
   };
@@ -191,6 +195,23 @@ export const LLMConnectionFlyoutForm: React.FunctionComponent<LLMConnectionFlyou
     // For now we don't need to do anything on
     setIsLoading(false);
   }, []);
+
+  React.useEffect(() => {
+    if (wizardData.editingLlm != undefined) {
+      console.log("loading llm elements");
+      setName(wizardData.editingLlm.name ?? "");
+      setDescription(wizardData.editingLlm.description ?? "");
+      setModelType(wizardData.editingLlm.modelType ?? "");
+      setServingRuntimeType(wizardData.editingLlm.servingRuntimeType ?? "");
+      setModelName(wizardData.editingLlm.modelName ?? "");
+      setUrl(wizardData.editingLlm.url ?? "");
+      // This isn't being returned by the API
+      setApiKey(wizardData.editingLlm.apiKey ?? "");
+      setTemperatureString(wizardData.editingLlm.temperature?.toString() ?? "");
+      setTemperature(wizardData.editingLlm.temperature ?? 0.0);
+      setMaxTokens(wizardData.editingLlm.maxTokens ?? 0);
+    }
+  }, [wizardData.editingLlm]);
 
   return isLoading ? (
     <FlyoutLoading />
@@ -371,7 +392,7 @@ export const LLMConnectionFlyoutForm: React.FunctionComponent<LLMConnectionFlyou
       {!error && (
         <FlyoutFooter
           isPrimaryButtonDisabled={validated !== 'success'}
-          primaryButton="Create LLM Connection"
+          primaryButton={wizardData.editingLlm !== undefined && wizardData.editingLlm.id !== null ?  "Update LLM Connection" : "Create LLM Connection"}
           onPrimaryButtonClick={onClick}
           secondaryButton="Cancel"
           onSecondaryButtonClick={prevStep}

--- a/src/app/FlyoutList/FlyoutList.tsx
+++ b/src/app/FlyoutList/FlyoutList.tsx
@@ -115,6 +115,21 @@ export const FlyoutList: React.FunctionComponent<FlyoutListProps> = ({
     loadItems();
   };
 
+  const editSelectedItem = async () => {
+    if (selectedItem == null) {
+      console.error("no item selected");
+      return;
+    }
+
+    if (componentType == ComponentType.ASSISTANT) {
+      nextStep({editingAssistant: selectedItem});
+    } else if (componentType == ComponentType.KNOWLEDGE_SOURCE) {
+      nextStep({editingRetriever: selectedItem});
+    } else if (componentType == ComponentType.LLM_CONNECTION) {
+        nextStep({editingLlm: selectedItem});
+    }
+  };
+
   const loadItems = async () => {
     if (reloadList) {
       await getItems();
@@ -124,6 +139,7 @@ export const FlyoutList: React.FunctionComponent<FlyoutListProps> = ({
   };
 
   React.useEffect(() => {
+    setSelectedItem(null);
     setReloadList(true);
     loadItems();
   }, [componentType]);
@@ -148,12 +164,17 @@ export const FlyoutList: React.FunctionComponent<FlyoutListProps> = ({
 
   const onSelect = (_event: React.MouseEvent<Element, MouseEvent> | undefined, value) => {
     if (filteredItems.length > 0) {
-      const selectedItem = items.filter((item) => item.id === value)[0];
+      const selectedItem2 = items.filter((item) => item.id === value)[0];
 
-      setSelectedItem(selectedItem);
+      if (selectedItem2 === selectedItem) {
+        setSelectedItem(null);
+      }
+      else {
+        setSelectedItem(selectedItem2);
+      }
 
       if (componentType == ComponentType.ASSISTANT) {
-        updateFlyoutMenuSelectedChatbot(selectedItem);
+        updateFlyoutMenuSelectedChatbot(selectedItem2);
       }
       if (location.pathname !== '/') {
         navigate('/');
@@ -212,6 +233,9 @@ export const FlyoutList: React.FunctionComponent<FlyoutListProps> = ({
       <FlyoutFooter
         primaryButton={buttonText}
         onPrimaryButtonClick={onFooterButtonClick ?? nextStep}
+        thirdButton="Edit"
+        thirdButtonClick={editSelectedItem}
+        isThirdButtonDisabled={selectedItem == null}
         dangerSecondaryButton="Delete"
         onDangerSecondaryButtonClick={deleteSelectedItem}
       />

--- a/src/app/FlyoutWizard/FlyoutWizardContext.tsx
+++ b/src/app/FlyoutWizard/FlyoutWizardContext.tsx
@@ -1,25 +1,43 @@
 import * as React from 'react';
+import {Assistant} from "@sdk/model";
+import { RetrieverConnection } from '@sdk/model';
+import { LLMConnection } from '@sdk/model';
+
+export interface WizardData {
+  editingAssistant?: Assistant;
+  editingRetriever?: RetrieverConnection;
+  editingLlm?: LLMConnection;
+}
 
 interface FlyoutWizardContextType {
   currentStep: number;
-  nextStep: () => void;
+  nextStep: (p?: { editingRetriever?: unknown, editingAssistant?: unknown, editingLlm?: unknown }) => void;
   prevStep: () => void;
   goToStep: (step: number) => void;
   reloadList: boolean;
   setReloadList: (bool: boolean) => void;
+  wizardData : WizardData;
 }
 
 const FlyoutWizardContext = React.createContext<FlyoutWizardContextType | undefined>(undefined);
 
 export const FlyoutWizardProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const [currentStep, setCurrentStep] = React.useState(0);
+  const [wizardData, setWizardData] = React.useState({});
   const [reloadList, setReloadList] = React.useState(false);
-  const nextStep = () => setCurrentStep((prev) => prev + 1);
-  const prevStep = () => setCurrentStep((prev) => prev - 1);
+  const nextStep = (data = {}) => {
+    setWizardData( (prev) => ({...prev, ...data}));
+    setCurrentStep((prev) => prev + 1);
+  }
+  const prevStep = () => {
+    setCurrentStep((prev) => prev - 1);
+    setWizardData(()=> ({}));
+
+  }
   const goToStep = (step: number) => setCurrentStep(step);
 
   return (
-    <FlyoutWizardContext.Provider value={{ currentStep, nextStep, prevStep, goToStep, reloadList, setReloadList }}>
+    <FlyoutWizardContext.Provider value={{ currentStep, nextStep, prevStep, goToStep, reloadList, setReloadList, wizardData }}>
       {children}
     </FlyoutWizardContext.Provider>
   );


### PR DESCRIPTION
Added the ability to edit existing objects using the forms for Assistants, Knowledge Sources and LLM Connections.  

There are some issues with this that I think need to be addressed in subsequent PRs:

* The default entries for Knowledge Sources & LLM Connections aren't fully populated thus editing them is awkward.  For example, "Host" is a required field for knowledge source but not populated for the default knowledge sources so you can't modify them.  Similarly, llm_default  has empty fields that are required.
* I think there should be a boolean for "override server defaults" and make these fields conditional if the user desires to set them
* Some fields are not being returned by the API (username / password for Knowledge sources and API Token for LLM Connections) thus you can't roundtrip edit these.

Some other notes about this PR:
* I made RAG optional for assistants.  This seems in-line with some of the default entry but wasn't possible from the UI
* Disabled editing assistant names after creation.  This was to keep the validation logic in check.
* You can now re-click on an item in the list to deselect it.  