### PR TITLE
Adding environment variables for theming support and to disable the sidebar menu

### DIFF
--- a/public/config-local.json
+++ b/public/config-local.json
@@ -1,3 +1,6 @@
 {
-  "REACT_APP_BASE_URL": "http://localhost:8080"
+  "REACT_APP_BASE_URL": "http://localhost:8080",
+  "LOGO_PATH_LIGHT": "./images/Logo-Red_Hat-Composer_AI_Studio-A-Standard-RGB.svg",
+  "LOGO_PATH_DARK": "./images/Logo-Red_Hat-Composer_AI_Studio-A-Reverse.svg",
+  "DISABLE_SIDE_MENU": "false"
 }

--- a/public/config.json
+++ b/public/config.json
@@ -1,3 +1,6 @@
 {
-  "REACT_APP_BASE_URL": "https://quarkus-llm-router-rhsaia-v2-dev.apps.rhsaia.vg6c.p1.openshiftapps.com"
+  "REACT_APP_BASE_URL": "https://quarkus-llm-router-rhsaia-v2-dev.apps.rhsaia.vg6c.p1.openshiftapps.com",
+  "LOGO_PATH_LIGHT": "./images/Logo-Red_Hat-Composer_AI_Studio-A-Standard-RGB.svg",
+  "LOGO_PATH_DARK": "./images/Logo-Red_Hat-Composer_AI_Studio-A-Reverse.svg",
+  "DISABLE_SIDE_MENU": "false"
 }

--- a/src/app/AppLayout/AppLayout.tsx
+++ b/src/app/AppLayout/AppLayout.tsx
@@ -12,19 +12,18 @@ import {
   SkipToContent,
 } from '@patternfly/react-core';
 import { BarsIcon } from '@patternfly/react-icons';
-import logo from '@app/bgimages/Logo-Red_Hat-Composer_AI_Studio-A-Standard-RGB.svg';
-import logoDark from '@app/bgimages/Logo-Red_Hat-Composer_AI_Studio-A-Reverse.svg';
+import { Properties } from '@app/Properties';
 import { SidebarWithFlyout } from '@app/SidebarWithFlyout/SidebarWithFlyout';
 import { AppDataProvider } from '@app/AppData/AppDataContext';
 
 const AppLayout: React.FunctionComponent = () => {
-  const [sidebarOpen, setSidebarOpen] = React.useState(true);
+  const [sidebarOpen, setSidebarOpen] = React.useState(false);
 
   // If you close the sidebar on mobile and go back to desktop, you lose it forever (or at least until reload)
   // This forces it to reopen if that happens.
   React.useEffect(() => {
     const updateSidebar = () => {
-      if (window.innerWidth >= 1200) {
+      if (window.innerWidth >= 1200 && !Properties.disableSidebar) {
         setSidebarOpen(true);
       }
     };
@@ -35,9 +34,10 @@ const AppLayout: React.FunctionComponent = () => {
     };
   }, []);
 
-  const masthead = (
+  const masthead =  ( disableSidebar: boolean ) => (
     <Masthead display={{ default: 'inline' }}>
       <MastheadMain>
+        { !disableSidebar &&
         <MastheadToggle>
           <Button
             icon={<BarsIcon />}
@@ -46,13 +46,14 @@ const AppLayout: React.FunctionComponent = () => {
             aria-label="Global navigation"
           />
         </MastheadToggle>
+        }
         <MastheadBrand data-codemods>
           <MastheadLogo data-codemods>
             <div className="show-light">
-              <Brand src={logo} alt="Red Hat Composer AI Studio" heights={{ default: '36px' }} />
+              <Brand src={Properties.logoWhiteUrl} alt="Red Hat Composer AI Studio" heights={{ default: '36px' }} />
             </div>
             <div className="show-dark">
-              <Brand src={logoDark} alt="Red Hat Composer AI Studio" heights={{ default: '36px' }} />
+              <Brand src={Properties.logoDarkUrl} alt="Red Hat Composer AI Studio" heights={{ default: '36px' }} />
             </div>
           </MastheadLogo>
         </MastheadBrand>
@@ -82,7 +83,7 @@ const AppLayout: React.FunctionComponent = () => {
       <Page
         className="chatbot-ui-page"
         mainContainerId={pageId}
-        masthead={masthead}
+        masthead={masthead(Properties.disableSidebar)}
         sidebar={sidebarOpen && Sidebar}
         skipToContent={PageSkipToContent}
         isContentFilled

--- a/src/app/Properties.tsx
+++ b/src/app/Properties.tsx
@@ -1,4 +1,4 @@
-export const getUrl = async () => {
+export const getConfig = async () => {
   let configUrl = './public/config.json';
   if (process.env.NODE_ENV === 'development' || process.env.NODE_ENV === 'test') {
     configUrl = './public/config-local.json';
@@ -9,20 +9,28 @@ export const getUrl = async () => {
       throw new Error('Failed to load config');
     }
     const config = await response.json();
-    const url = config.REACT_APP_BASE_URL;
 
-    if (!url) {
-      throw new Error('API URL is not configured.');
-    }
-
-    return url;
+    return config;
   } catch (error) {
     console.error('Error fetching chatbots:', error);
     throw error;
   }
 };
 
-const backendUrl = (await getUrl()) || 'http://localhost:8080';
+
+const config = await getConfig();
+
+const url = config.REACT_APP_BASE_URL;
+
+if (!url) {
+  throw new Error('API URL is not configured.');
+}
+const backendUrl = (url || 'http://localhost:8080');
+const logoLightUrl = (config.LOGO_PATH_LIGHT || './images/Logo-Red_Hat-Composer_AI_Studio-A-Standard-RGB.svg');
+const logoDarkUrl = (config.LOGO_PATH_DARK || './images/Logo-Red_Hat-Composer_AI_Studio-A-Reverse.svg');
+console.log("logoDark: "  + logoDarkUrl + " logoLight: " + logoLightUrl);
+
+const disableSidebar = config.DISABLE_SIDE_MENU === "true" ;
 
 export const Properties = {
   backendUrl: backendUrl,
@@ -35,4 +43,9 @@ export const Properties = {
 
   // TODO: Create a real auth URL that points to info on the user
   authUrl: backendUrl + '/admin/assistant',
+
+  logoWhiteUrl: logoLightUrl,
+  logoDarkUrl: logoDarkUrl,
+
+  disableSidebar: disableSidebar
 };

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -123,6 +123,8 @@ module.exports = (env) => {
           { from: './src/favicon.ico', to: 'images' },
           { from: './src/favicon.svg', to: 'images' },
           { from: './src/favicon.png', to: 'images' },
+          { from: './src/app/bgimages/Logo-Red_Hat-Composer_AI_Studio-A-Reverse.svg', to: 'images' },
+          { from: './src/app/bgimages/Logo-Red_Hat-Composer_AI_Studio-A-Standard-RGB.svg', to: 'images' },
           { from: './src/apple-touch-icon.png', to: 'images' },
           { from: './src/favicon-48x48.png', to: 'images' },
           { from: './src/web-app-manifest-192x192.png', to: 'images' },


### PR DESCRIPTION
This commit adds the ability to reference URLs for theming with alternate logos and to disable the hamburger menu bar in the upper left.  

For example with these env variables:

```
  "LOGO_PATH_DARK": "https://raw.githubusercontent.com/rh-aiservices-bu/parasol-insurance/refs/heads/main/app/frontend/src/favicon.svg",
  "DISABLE_SIDE_MENU": "true"
```

You get:

![image](https://github.com/user-attachments/assets/c2e9291b-1589-4b48-977a-9861fc1beccc)

Note, these properties are specified in the `config.json` and `config-local.json` files however they are all optional and the code defaults to the existing behavior.  